### PR TITLE
Test PR without the `docs-lint` target

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Gravity Docs
 
 Gravity docs are built using [mkdocs](http://www.mkdocs.org/) and hosted as static files
-on CloudFlare CDN. Located here https://gravitational.com/gravity/docs/overview/ 
+on CloudFlare CDN. Located here https://gravitational.com/gravity/docs/overview/
 
 Look at `build.sh` script to see how it works.
 
@@ -18,19 +18,19 @@ See `web/README.md` for more info.
 
 ## Running Locally
 
-We recommend using Docker to run and build the docs. 
+We recommend using Docker to run and build the docs.
 
-`make run` will create a build a local Docker environment, compile the docs and 
+`make run` will create a build a local Docker environment, compile the docs and
 setup a [livereload server](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en) for easy previewing of changes by opening
-http://localhost:6600/overview/ in your local browser. 
+http://localhost:6600/overview/ in your local browser.
 
 
-`make docs` will build the docs, so they are ready to ship to production. 
+`make docs` will build the docs, so they are ready to ship to production.
 
 
 ## Tools used to build the Docs
 
-Gravity docs are made with MkDocs and a few markdown extensions, First time users will need to install [MkDocs](https://www.mkdocs.org/#installation). 
+Gravity docs are made with MkDocs and a few markdown extensions, First time users will need to install [MkDocs](https://www.mkdocs.org/#installation).
 
 To run the latest version of the docs on [http://127.0.0.1:8000](http://127.0.0.1:8000/quickstart):
 


### PR DESCRIPTION
This PR exercises the gravity-pr-docs jenkins job I built today, but with a branch that has no `make docs-lint` target.  This is important to make sure we don't break PRs to legacy branches.